### PR TITLE
Fixing "Cannot read property 'indexOf' of null"

### DIFF
--- a/hermes.js
+++ b/hermes.js
@@ -127,6 +127,7 @@
         }
 
         window.addEventListener('storage', e => {
+            if (!e.key) return;
             if (e.key.indexOf(prefix) === 0 && e.oldValue === null) {
                 const topic = e.key.replace(prefix, '');
                 const data = JSON.parse(e.newValue);
@@ -135,6 +136,7 @@
         });
 
         window.addEventListener('storage', e => {
+            if (!e.key) return;
             if (e.key.indexOf(prefix) === 0 && e.newValue === null) {
                 const topic = e.key.replace(prefix, '');
                 if (topic in queue) {


### PR DESCRIPTION
We have just picked that error up in production. We can't reproduce it. However, it did happen.

Browser: Chrome 75.0.3770 (latest atm)
OS: Windows 10

If this fix is wrong then please close this PR and fix in a proper way.